### PR TITLE
reducing resource cost of default deployment

### DIFF
--- a/loader/innodb_sb
+++ b/loader/innodb_sb
@@ -35,8 +35,8 @@ sysbench \
 while true; do
     sysbench \
         $SB_CONNECTION \
-        --rate=20 \
-        --threads=64 \
+        --rate=1 \
+        --threads=1 \
         --report-interval=10 \
         --time=0 \
         --events=0 \

--- a/loader/innodb_sb_spike
+++ b/loader/innodb_sb_spike
@@ -19,7 +19,7 @@ fi
 while true; do
     sysbench \
         $SB_CONNECTION \
-        --threads=64 \
+        --threads=1 \
         --report-interval=10 \
         --time=300 \
         --events=0 \

--- a/loader/myisam_sb
+++ b/loader/myisam_sb
@@ -26,8 +26,8 @@ sysbench \
 
 while true; do
     sysbench \
-        --rate=3 \
-        --threads=64 \
+        --rate=1 \
+        --threads=1 \
         --report-interval=10 \
         --time=0 \
         --events=0 \

--- a/loader/small_sb
+++ b/loader/small_sb
@@ -26,8 +26,8 @@ sysbench \
 
 while true; do
     sysbench \
-        --rate=200 \
-        --threads=64 \
+        --rate=1 \
+        --threads=1 \
         --report-interval=10 \
         --time=0 \
         --events=0 \


### PR DESCRIPTION
setting rate and threads to 1 to keep initial deployment of the benchmarks run-able on 1cpu systems